### PR TITLE
Fix isapprox for dictionaries in testing (and highlight existing errors)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,8 +12,8 @@ function Base.isapprox(seq1::AbstractDict, seq2::AbstractDict)
     for (k1,v1) in seq1
         k1 ∈ keys(seq2) || (println("key $k1 missing from seq2"); return false)
         if v1 isa AbstractDict
-            return isapprox(v1, seq2[k1])
-        elseif v1 isa Array{AbstractFloat} || v1 isa AbstractFloat
+            v1 ≈ seq2[k1] || (println("key $k1: $v1 !≈ $(seq2[k1])"); return false)
+        elseif v1 isa Array{<:AbstractFloat} || v1 isa AbstractFloat
             v1 ≈ seq2[k1]  || (println("key $k1: $v1 !≈ $(seq2[k1])"); return false)
         else
             v1 == seq2[k1] || (println("key $k1: $v1 != $(seq2[k1])"); return false)


### PR DESCRIPTION
It seems that the fixes yesterday for the data transposition worked for the positions but have broken the cell vectors. You can see this in the README example where the typo in the cell vectors `Lattice="5.44 0.0 0.0 0.0 5.44 0.0 0.0 0.05.44"` becomes 

```
"cell": [
      [
         5.44,
         0.0,
         0.0
      ],
      [
         0.0,
         5.44,
         0.05
      ],
      [
         0.0,
         0.0,
         0.44
      ]
   ]
```
whereas it should be
```
"cell": [
      [
         5.44,
         0.0,
         0.0
      ],
      [
         0.0,
         5.44,
         0.0
      ],
      [
         0.0,
         0.05,
         0.44
      ]
   ]
```

This issue was being hidden by the isapprox function which was causing the comparison to exit early before comparing all the fields. It would compare the sub-dictionary "arrays" and return true before comparing the cells.

So this pull request should cause the tests to fail and highlight that the cells are not being transformed correctly.