### PR TITLE
Fix testing and transpose bug

### DIFF
--- a/src/ExtXYZ.jl
+++ b/src/ExtXYZ.jl
@@ -382,7 +382,7 @@ read_frames(file::Union{String,IOStream}; kwargs...) = read_frames(file, Iterato
 
 function write_frame_dicts(fp::Ptr{Cvoid}, nat, info, arrays; verbose=false)
     nat = Cint(nat)
-    cinfo = convert(Ptr{DictEntry}, info)
+    cinfo = convert(Ptr{DictEntry}, info; transpose_arrays=true)
 
     # ensure "species" goes in column 1 and "pos" goes in column 2
     ordered_keys = collect(keys(arrays))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,8 +12,8 @@ function Base.isapprox(seq1::AbstractDict, seq2::AbstractDict)
     for (k1,v1) in seq1
         k1 ∈ keys(seq2) || (println("key $k1 missing from seq2"); return false)
         if v1 isa AbstractDict
-            return isapprox(v1, seq2[k1])
-        elseif v1 isa Array{AbstractFloat} || v1 isa AbstractFloat
+            v1 ≈ seq2[k1] || (println("key $k1: $v1 !≈ $(seq2[k1])"); return false)
+        elseif v1 isa Array{<:AbstractFloat} || v1 isa AbstractFloat
             v1 ≈ seq2[k1]  || (println("key $k1: $v1 !≈ $(seq2[k1])"); return false)
         else
             v1 == seq2[k1] || (println("key $k1: $v1 != $(seq2[k1])"); return false)


### PR DESCRIPTION
@jamesgardner1421 this concludes your PR #12 - there was a missing transpose when writing out the info dict entries. I hope this is everything now. I had misunderstood your earlier change to `isapprox()` it works perfectly - thanks for picking that up.