### PR TITLE
Add support for molecular xyzs without Lattice key

### DIFF
--- a/src/ExtXYZ.jl
+++ b/src/ExtXYZ.jl
@@ -305,7 +305,7 @@ function read_frame(fp::Ptr{Cvoid}; verbose=false)
 
     # cell is transpose of the stored lattice
     lattice = extract_lattice!(info)
-    dict["cell"] = permutedims(lattice, (2, 1))
+    if (!isnothing(lattice)) dict["cell"] = permutedims(lattice, (2, 1)) end
 
     delete!(info, "Properties")
 
@@ -415,7 +415,7 @@ can be a file pointer, open IO stream or string filename.
 function write_frame(fp::Ptr{Cvoid}, dict; verbose=false)
     nat = dict["N_atoms"]
     info = copy(dict["info"])
-    info["Lattice"] = permutedims(dict["cell"], (2, 1))
+    if ("cell" in keys(dict)) info["Lattice"] = permutedims(dict["cell"], (2, 1)) end
     info["pbc"] = get(dict, "pbc", [true, true, true])
 
     write_frame_dicts(fp, nat, info, dict["arrays"]; verbose=verbose)


### PR DESCRIPTION
It appears that support for this can be added by simply omitting read/write to `dict["cell"]` whenever the `Lattice` key isn't provided in the info dict. From my testing it appears as though the C backend can handle writing without `info["Lattice"]` without issue.