### PR TITLE
velocity(s::Atoms) throws an error if velocities are not defined

### DIFF
--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -160,13 +160,14 @@ position(s::Atoms)       = s.atom_data.positions
 atomic_symbol(s::Atoms)  = s.atom_data.atomic_symbols
 atomic_number(s::Atoms)  = s.atom_data.atomic_numbers
 atomic_mass(s::Atoms)    = s.atom_data.atomic_masses
-velocity(s::Atoms)       = s.atom_data.velocities
+velocity(s::Atoms)       = haskey(s.atom_data, :velocities) ? s.atom_data.velocities : missing
 
 position(s::Atoms, i)      = s.atom_data.positions[i]
 atomic_symbol(s::Atoms, i) = s.atom_data.atomic_symbols[i]
 atomic_number(s::Atoms, i) = s.atom_data.atomic_numbers[i]
 atomic_mass(s::Atoms, i)   = s.atom_data.atomic_masses[i]
-velocity(s::Atoms, i)      = s.atom_data.velocity[i]
+#Double Check
+velocity(s::Atoms, i)      = haskey(s.atom_data, :velocities) ? s.atom_data.velocities[i] : missing
 
 function Base.show(io::IO, system::Atoms)
     print(io, "Atoms")

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -166,7 +166,6 @@ position(s::Atoms, i)      = s.atom_data.positions[i]
 atomic_symbol(s::Atoms, i) = s.atom_data.atomic_symbols[i]
 atomic_number(s::Atoms, i) = s.atom_data.atomic_numbers[i]
 atomic_mass(s::Atoms, i)   = s.atom_data.atomic_masses[i]
-#Double Check
 velocity(s::Atoms, i)      = haskey(s.atom_data, :velocities) ? s.atom_data.velocities[i] : missing
 
 function Base.show(io::IO, system::Atoms)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,14 @@ Si        13.00000000      14.00000000      $(frame+1).00000000          0      
                 @test(sys2.system_data[:Stress] == [13,14])
                 @test(sys2.system_data[:conv_vec] == [0.10, 0.11, 0.12])
                 @test(sys2.system_data[:conv_val] == 0.13)
+                #Test without velocities
+                atom_data = Dict(:positions => [[1,2,3],[2,3,4]].*10^(-12)*u"m", :atomic_numbers => [25, 25], :atomic_symbols => [:Mn, :Mn])
+                sys1 = Atoms(NamedTuple(atom_data), NamedTuple(system_data))
+                ExtXYZ.save(outfile, sys1)
+                sys2 = ExtXYZ.load(outfile)
+                @test(ismissing(velocity(sys2)))
+                @test(ismissing(velocity(sys2[1])))
+                @test(ismissing(velocity(sys2, 1)))
             end
         end
 


### PR DESCRIPTION
Hello,
I changed `velocity(s::Atoms)`, `velocity(s::Atoms, i)` to return missing, if the velocities are not defined.
Additionally `s.atom_data.velocity[i]` should be `s.atom_data.velocities[i]`
Currently, there is no porper way for AtomsBase users to ckeck if a system has velocities, excpet if the velocities are either 0 or missing and AtomsBases `FastSystem` uses missing for that. The documentation [https://juliamolsim.github.io/AtomsBase.jl/stable/apireference/#AtomsBase.velocity](url) even explictitly allows missing as a return value.