### PR TITLE
Increase test tolerance a little

### DIFF
--- a/test/atomsbase.jl
+++ b/test/atomsbase.jl
@@ -86,5 +86,5 @@ end
         ExtXYZ.save(outfile, system)
         ExtXYZ.load(outfile)::AbstractSystem
     end
-    test_approx_eq(system, io_system; rtol=1e-6)
+    test_approx_eq(system, io_system; rtol=1e-4)
 end


### PR DESCRIPTION
The issue is that IO involves serialisation to string and potential unit conversion, which is inherently brittle. We just care to catch accidental unit errors or accidental forgotten parameters etc, so raising the relative tolerance should be fine.