### PR TITLE
Generalise system properties type check

### DIFF
--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -53,7 +53,7 @@ function Atoms(system::AbstractSystem{D})
         atoms_base_keys = (:charge, :covalent_radius, :vdw_radius,
                            :magnetic_moment, :pseudopotential)
         v = system[1, k]
-        if k in atoms_base_keys || v isa ExtxyzType
+        if k in atoms_base_keys || v isa ExtxyzType || v isa AbstractVector{<: ExtxyzType}
             # These are either Unitful quantities, which are uniformly supported
             # across all of AtomsBase or the value has a type that Extxyz can write
             # losslessly, so we can just write them no matter the value
@@ -136,7 +136,7 @@ function Atoms(dict::Dict{String, Any})
         elseif key in ("charge", )  # Add charge unit
             atom_data[Symbol(key)] = arrays[key] * u"e_au"
         elseif typeof(arrays[key]) <: AbstractMatrix
-            atom_data[Symbol(key)] = [ collect(col) for col in eachcol(arrays[key]) ]  
+            atom_data[Symbol(key)] = [ collect(col) for col in eachcol(arrays[key]) ]
         else
             atom_data[Symbol(key)] = arrays[key]
         end


### PR DESCRIPTION
Currently the type checks in the AtomsBase interface are a little too strict.

Note, however, that for some reason the leading dimension needs to be 3 otherwise there is a segfault when reading back in the data (could be a bug ?).