### PR TITLE
Make compatible with AtomsBase 0.4.x

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "ExtXYZ"
 uuid = "352459e4-ddd7-4360-8937-99dcb397b478"
 authors = ["James Kermode <J.R.Kermode@warwick.ac.uk> and contributors"]
-version = "0.2-DEV"
+version = "0.2.0-DEV"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
+AtomsBaseTesting = "ed7c10db-df7e-4efa-a7be-4f4190f7f227"
 PeriodicTable = "7b2266bf-644c-5ea3-82d8-af4bbd25a884"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
@@ -17,8 +18,8 @@ PeriodicTable = "1"
 StaticArrays = "1.5"
 Unitful = "1"
 UnitfulAtomic = "1"
-julia = "1"
 extxyz_jll = "0.1.3"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 extxyz_jll = "6ecdc6fc-93a8-5528-aee3-ac7ae1c60be7"
 
 [compat]
-AtomsBase = "0.4"
+AtomsBase = "0.4.1"
 PeriodicTable = "1"
 StaticArrays = "1.5"
 Unitful = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExtXYZ"
 uuid = "352459e4-ddd7-4360-8937-99dcb397b478"
 authors = ["James Kermode <J.R.Kermode@warwick.ac.uk> and contributors"]
-version = "0.2.0-DEV"
+version = "0.2.0-dev"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
@@ -13,7 +13,7 @@ UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 extxyz_jll = "6ecdc6fc-93a8-5528-aee3-ac7ae1c60be7"
 
 [compat]
-AtomsBase = "0.3, 0.4"
+AtomsBase = "0.4"
 PeriodicTable = "1"
 StaticArrays = "1.5"
 Unitful = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ExtXYZ"
 uuid = "352459e4-ddd7-4360-8937-99dcb397b478"
 authors = ["James Kermode <J.R.Kermode@warwick.ac.uk> and contributors"]
-version = "0.1.15-DEV"
+version = "0.2-DEV"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"
@@ -12,7 +12,7 @@ UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 extxyz_jll = "6ecdc6fc-93a8-5528-aee3-ac7ae1c60be7"
 
 [compat]
-AtomsBase = "0.3"
+AtomsBase = "0.3, 0.4"
 PeriodicTable = "1"
 StaticArrays = "1.5"
 Unitful = "1"

--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -24,30 +24,30 @@ end
 function Atoms(system::AbstractSystem{D})
     n_atoms = length(system)
     atomic_symbols = [Symbol(element(atomic_number(at)).symbol) for at in system]
-    if atomic_symbols != atomic_symbol(system)
+    if atomic_symbols != atomic_symbol(system, :)
         @warn("Mismatch between atomic numbers and atomic symbols, which is not supported " *
               "in ExtXYZ. Atomic numbers take preference.")
     end
     atom_data = Dict{Symbol,Any}(
         :atomic_symbol => atomic_symbols,
         :atomic_number => atomic_number(system),
-        :atomic_mass   => atomic_mass(system)
+        :mass   => mass(system)
     )
     atom_data[:position] = map(1:n_atoms) do at
         pos = zeros(3)u"Å"
         pos[1:D] = position(system, at)
-        pos
+        SVector{D, eltype(pos)}(pos)  # AtomsBase 0.4 requires SVector
     end
     atom_data[:velocity] = map(1:n_atoms) do at
         vel = zeros(3) * uVelocity
         if !ismissing(velocity(system)) && !ismissing(velocity(system, at))
             vel[1:D] = velocity(system, at)
         end
-        vel
+        SVector{D, eltype(pos)}(vel)  # AtomsBase 0.4 requires SVector
     end
 
     for k in atomkeys(system)
-        if k in (:atomic_symbol, :atomic_number, :atomic_mass, :velocity, :position)
+        if k in (:atomic_symbol, :atomic_number, :mass, :velocity, :position)
             continue  # Already done
         end
         atoms_base_keys = (:charge, :covalent_radius, :vdw_radius,
@@ -65,20 +65,14 @@ function Atoms(system::AbstractSystem{D})
         end
     end
 
-    box = map(1:3) do i
-        v = zeros(3)u"Å"
-        i ≤ D && (v[1:D] = bounding_box(system)[i])
-        v
-    end
     system_data = Dict{Symbol,Any}(
-        :bounding_box => box,
-        :boundary_conditions => boundary_conditions(system)
+        :bounding_box => bounding_box(system)  # NTuple{D, SVector},
+        :periodicity => periodicity(system)    # NTuple{D, Bool}
     )
 
     # Extract extra system properties
-    system_data = Dict{Symbol,Any}()
     for (k, v) in pairs(system)
-        atoms_base_keys = (:charge, :multiplicity, :boundary_conditions, :bounding_box)
+        atoms_base_keys = (:charge, :multiplicity, :periodicity, :bounding_box)
         if k in atoms_base_keys || v isa ExtxyzType || v isa AbstractArray{<: ExtxyzType}
             # These are either Unitful quantities, which are uniformly supported
             # across all of AtomsBase or the value has a type that Extxyz can write
@@ -119,9 +113,9 @@ function Atoms(dict::Dict{String, Any})
         atom_data[:atomic_symbol] = [Symbol(element(num).symbol) for num in Z]
     end
     if haskey(arrays, "mass")
-        atom_data[:atomic_mass] = arrays["mass"]u"u"
+        atom_data[:mass] = arrays["mass"]u"u"
     else
-        atom_data[:atomic_mass] = [element(num).atomic_mass for num in Z]
+        atom_data[:mass] = [element(num).atomic_mass for num in Z]
     end
     if haskey(arrays, "velocities")
         atom_data[:velocity] = collect(eachcol(arrays["velocities"])) * uVelocity
@@ -146,16 +140,17 @@ function Atoms(dict::Dict{String, Any})
     if haskey(dict, "cell")
         system_data[:bounding_box] = collect(eachrow(dict["cell"]))u"Å"
         if haskey(dict, "pbc")
-            system_data[:boundary_conditions] = [p ? Periodic() : DirichletZero()
-                                                 for p in dict["pbc"]]
+            system_data[:periodicity] = tuple(dict["pbc"]...)
         else
             @warn "'pbc' not contained in dict. Defaulting to all-periodic boundary. "
-            system_data[:boundary_conditions] = fill(Periodic(), 3)
+            system_data[:periodicity] = (true, true, true)
         end
     else  # Infinite system
         haskey(dict, "pbc") && @warn "'pbc' ignored since no 'cell' entry found in dict."
-        system_data[:boundary_conditions] = fill(DirichletZero(), 3)
-        system_data[:bounding_box] = infinite_box(3)
+        system_data[:periodicity] = (false, false, false) 
+        system_data[:bounding_box] = ( SVector(Inf, 0.0, 0.0), 
+                                       SVector(0.0, Inf, 0.0), 
+                                       SVector(0.0, 0.0, Inf) )
     end
 
     for key in keys(info)
@@ -168,6 +163,7 @@ function Atoms(dict::Dict{String, Any})
 
     Atoms(NamedTuple(atom_data), NamedTuple(system_data))
 end
+
 read_dict(dict::Dict{String,Any}) = Atoms(dict)
 
 function write_dict(atoms::Atoms)
@@ -180,7 +176,7 @@ function write_dict(atoms::Atoms)
               "in ExtXYZ. Atomic numbers take preference.")
     end
     if atoms.atom_data.atomic_mass != [element(Z).atomic_mass for Z in arrays["Z"]]
-        arrays["mass"] = ustrip.(u"u", atoms.atom_data.atomic_mass)
+        arrays["mass"] = ustrip.(u"u", atoms.atom_data.mass)
     end
 
     arrays["velocities"] = zeros(D, length(atoms))
@@ -193,7 +189,7 @@ function write_dict(atoms::Atoms)
     end
 
     for (k, v) in pairs(atoms.atom_data)
-        k in (:atomic_mass, :atomic_symbol, :atomic_number, :position, :velocity) && continue
+        k in (:mass, :atomic_symbol, :atomic_number, :position, :velocity) && continue
         if k in (:vdw_radius, :covalent_radius)  # Remove length unit
             arrays[string(k)] = ustrip.(u"Å", v)
         elseif k in (:charge, )
@@ -207,10 +203,7 @@ function write_dict(atoms::Atoms)
         end
     end
 
-    pbc = zeros(Bool, D)
-    for (i, bc) in enumerate(atoms.system_data.boundary_conditions)
-        pbc[i] = bc isa Periodic
-    end
+    pbc = atoms.system_data.periodicity
     cell = zeros(D, D)
     for (i, bvector) in enumerate(atoms.system_data.bounding_box)
         cell[i, :] = ustrip.(u"Å", bvector)
@@ -219,7 +212,7 @@ function write_dict(atoms::Atoms)
     # Deal with other system keys
     info = Dict{String,Any}()
     for (k, v) in pairs(atoms.system_data)
-        k in (:boundary_conditions, :bounding_box) && continue # Already dealt with
+        k in (:periodicity, :bounding_box) && continue # Already dealt with
         if k in (:charge, )
             info[string(k)] = ustrip(u"e_au", atoms.system_data[k])
         elseif v isa ExtxyzType
@@ -249,9 +242,14 @@ write_dict(system::AbstractSystem{D}) = write_dict(Atoms(system))
 Base.length(sys::Atoms) = length(sys.atom_data.position)
 Base.size(sys::Atoms)   = (length(sys), )
 AtomsBase.bounding_box(sys::Atoms) = sys.system_data.bounding_box
-AtomsBase.boundary_conditions(sys::Atoms) = sys.system_data.boundary_conditions
+AtomsBase.periodicity(sys::Atoms) = sys.system_data.periodicity
 
-AtomsBase.species_type(::FS) where {FS <: Atoms} = AtomView{FS}
+# AtomsBase now requires a cell object to be returned instead of bounding_box 
+# and boundary conditions. But this can just be constructed on the fly. 
+AtomsBase.cell(sys::Atoms) = AtomsBase.PeriodicCell(; 
+                cell_vectors = sys.system_data.bounding_box, 
+                 periodicity = sys.system_data.periodicity )
+
 Base.getindex(sys::Atoms, x::Symbol) = getindex(sys.system_data, x)
 Base.haskey(sys::Atoms, x::Symbol)   = haskey(sys.system_data, x)
 Base.keys(sys::Atoms) = keys(sys.system_data)
@@ -263,16 +261,17 @@ Base.getindex(sys::Atoms, ::Colon,    x::Symbol) = getindex(sys.atom_data, x)
 AtomsBase.atomkeys(sys::Atoms) = keys(sys.atom_data)
 AtomsBase.hasatomkey(sys::Atoms, x::Symbol) = haskey(sys.atom_data, x)
 
-AtomsBase.position(s::Atoms)                  = Base.getindex(s, :, :position)
-AtomsBase.position(s::Atoms, i::Integer)      = Base.getindex(s, i, :position)
-AtomsBase.velocity(s::Atoms)                  = Base.getindex(s, :, :velocity)
-AtomsBase.velocity(s::Atoms, i::Integer)      = Base.getindex(s, i, :velocity)
-AtomsBase.atomic_mass(s::Atoms)               = Base.getindex(s, :, :atomic_mass)
-AtomsBase.atomic_mass(s::Atoms, i::Integer)   = Base.getindex(s, i, :atomic_mass)
-AtomsBase.atomic_symbol(s::Atoms)             = Base.getindex(s, :, :atomic_symbol)
-AtomsBase.atomic_symbol(s::Atoms, i::Integer) = Base.getindex(s, i, :atomic_symbol)
-AtomsBase.atomic_number(s::Atoms)             = Base.getindex(s, :, :atomic_number)
-AtomsBase.atomic_number(s::Atoms, i::Integer) = Base.getindex(s, i, :atomic_number)
+const _IDX = Union{Colon, Integer, AbstractArray{<: Integer}}
+AtomsBase.position(s::Atoms, i::_IDX)      = getindex(s, i, :position)
+AtomsBase.velocity(s::Atoms, i::_IDX)      = getindex(s, i, :velocity)
+AtomsBase.mass(s::Atoms, i::_IDX)          = getindex(s, i, :mass)
+AtomsBase.atomic_symbol(s::Atoms, i::_IDX) = getindex(s, i, :atomic_symbol)
+AtomsBase.atomic_symbol(s::Atoms, i::_IDX) = getindex(s, i, :atomic_number)
+
+# AtomsBase now requires the `species` function to be implemented. Since 
+# ExtXYZ requires that atoms are uniquely identified by their atomic number, we 
+# will use the atomic number as the species identifier.
+AtomsBase.species(s::Atoms, i::_IDX) = AtomsBase.atomic_number(s, i)
 
 # --------- FileIO compatible interface (hence not exported)
 

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -359,7 +359,7 @@ function write_frame_dicts(fp::Ptr{Cvoid}, nat, info, arrays; verbose=false)
     nat = Cint(nat)
     cinfo = convert(Ptr{DictEntry}, info; transpose_arrays=true)
 
-    # ensure "species" goes in column 1 and "pos" goes in column 2
+    # ensure "species" (symbol!) goes in column 1 and "pos" goes in column 2
     ordered_keys = collect(keys(arrays))
     species_idx = findfirst(isequal("species"), ordered_keys)
     ordered_keys[1], ordered_keys[species_idx] = ordered_keys[species_idx], ordered_keys[1]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,5 @@
 [compat]
-AtomsBaseTesting = "0.1"
+AtomsBaseTesting = "0.2"
 
 [deps]
 AtomsBase = "a963bdd2-2df7-4f54-a1ee-49d51e6be12a"

--- a/test/atomsbase.jl
+++ b/test/atomsbase.jl
@@ -6,9 +6,6 @@ using Unitful
 using UnitfulAtomic
 using AtomsBase: AbstractSystem
 
-# AtomsBase.atomic_number(z::Integer) = z 
-AtomsBase.atomic_symbol(z::Integer) = AtomsBase._chem_el_info[z].symbol
-AtomsBase.atomic_number(s::Symbol) = AtomsBase._sym2z[s]
 
 function simple_test_approx_eq(sys1, sys2; test_cell = true)
     @test all(position(sys1, :) .≈ position(sys2, :))

--- a/test/atomsbase.jl
+++ b/test/atomsbase.jl
@@ -5,6 +5,13 @@ using Test
 using Unitful
 using UnitfulAtomic
 
+AtomsBase.atomic_number(z::Integer) = z 
+AtomsBase.atomic_symbol(z::Integer) = AtomsBase._chem_el_info[z].symbol
+
+system = make_test_system().system
+at_sys = Atoms(system)
+test_approx_eq(system, Atoms(system))
+
 @testset "Conversion AtomsBase -> Atoms" begin
     system = make_test_system().system
     test_approx_eq(system, Atoms(system))
@@ -33,7 +40,7 @@ end
     arrays = atoms["arrays"]
     @test arrays["Z"]          == atprop.atomic_number
     @test arrays["species"]    == string.(atprop.atomic_symbol)
-    @test arrays["mass"]       == ustrip.(u"u",  atprop.atomic_mass)
+    @test arrays["mass"]       == ustrip.(u"u",  atprop.mass)
     @test arrays["pos"]        ≈  ustrip.(u"Å",  hcat(atprop.position...)) atol=1e-10
     @test arrays["velocities"] ≈  ustrip.(sqrt(u"eV"/u"u"),
                                           hcat(atprop.velocity...)) atol=1e-10


### PR DESCRIPTION
The interface in AB0.4 changed slightly. This PR is to update. I don't plan to support both AB 0.3 and 0.4, so this would become a breaking change to be registered as ExtXYZ@0.2.

NB - tests still fail, I will ping once they pass. 