### PR TITLE
Add support for reading from IOBuffers

### DIFF
--- a/src/atoms.jl
+++ b/src/atoms.jl
@@ -289,9 +289,9 @@ AtomsBase.species(s::Atoms, i::_IDX) =
 
 # --------- FileIO compatible interface (hence not exported)
 
-load(file::Union{String,IOStream}, frame; kwargs...) = Atoms(read_frame(file, frame; kwargs...))
+load(file::Union{String,IOStream,IOBuffer}, frame; kwargs...) = Atoms(read_frame(file, frame; kwargs...))
 
-function load(file::Union{String,IOStream}; kwargs...)
+function load(file::Union{String,IOStream,IOBuffer}; kwargs...)
     seq = Atoms.(read_frames(file; kwargs...))
     if length(seq) == 1
         return seq[1]

--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -33,12 +33,12 @@ function cfopen(f::Function, filename::String, mode::String="r")
     end
 end
 
-function ExtXYZ.cfopen(f::Function, iob::IOBuffer, mode::String="r")
+function cfopen(f::Function, iob::IOBuffer, mode::String="r")
     fp = ccall(:fmemopen, Ptr{Cvoid}, (Ptr{Cvoid}, Cint, Cstring), pointer(iob.data, iob.ptr), iob.size, mode)
     try
         f(fp)
     finally
-        ExtXYZ.cfclose(fp)
+        cfclose(fp)
     end
 end
 

--- a/test/dict.jl
+++ b/test/dict.jl
@@ -64,6 +64,10 @@ Si        13.00000000      14.00000000      $(frame+1).00000000          0      
             close(f)
 
             @test all(seq1 .== seq3)
+
+            iob = IOBuffer(read(infile, String))
+            seq4 = read_frames(iob)
+            @test all(seq1 .== seq4)
         end
 
         @testset "convert" begin


### PR DESCRIPTION
My solution to the problem presented in #46 was workable but not great:
- Creating frames from Julia strings required using the slower Python implementation of `read_frames` through PythonCall.
- Frames created this way needed significant postprocessing to deal with all of the pythonic types of underlying elements so that they could be written with `write_frames`, as this needed everything to be a Julia type and not a PythonCall wrapper type.

To (hopefully) provide a better solution, I've implemented a new method of `cfopen` that internally calls the `fmemopen` C function. This returns what is functionally a  'file pointer' that the rest of ExtXYZ can work with as if it were an actual file.

I've extended the `read_frame` methods to allow for passing `IOBuffer`s and added a test case for equivalence with the regular read-from-file approach. I haven't added an equivalent method for `write_frame` yet but may do so after some testing.

The only bit I'm not sure about is the Windows `ccall` to `fmemopen` - I see that there's a special case for handling `fdopen` but I'm not familiar with how this works on Windows so please correct this if it needs to be.