### PR TITLE
Set julia compat floor to 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ StaticArrays = "1.5"
 Unitful = "1"
 UnitfulAtomic = "1"
 extxyz_jll = "0.4.4"
-julia = "1"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Unblocks registration of v0.4.4. General's AutoMerge tests installing/loading on the lowest declared Julia version; with `julia = "1"` that was 1.1.1, where `Pkg.add`/`import` fail because AtomsBase 0.5 requires julia ≥ 1.9 and extxyz_jll 0.4.4 is built for ≥ 1.6.

Sets the floor to `1.10`, matching the CI matrix (current LTS). No version bump — re-trigger registration on the merge commit to update the existing General PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)